### PR TITLE
Migrate paths to Path.Join for cross-platform compatibility

### DIFF
--- a/Apstory.ApstoryTsqlCodeGen.DapperGenerator/DapperGen.cs
+++ b/Apstory.ApstoryTsqlCodeGen.DapperGenerator/DapperGen.cs
@@ -3,6 +3,7 @@ using Apstory.ApstoryTsqlCodeGen.Shared.Service;
 using Apstory.ApstoryTsqlCodeGen.Shared.Models;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -74,10 +75,11 @@ namespace Apstory.ApstoryTsqlCodeGen.DapperGenerator
                 LogOutputLine();
                 string fileName = table.TABLE_NAME + "Repository" + (addSchemaPath ? "." + schema.ToUpper() : string.Empty) + ".Gen.cs";
                 string filePath;
+                
                 if (_GenPath.Length > 0)
-                    filePath = path + (addSchemaPath ? schema.ToUpper() + @"/" : string.Empty) + _GenPath.Replace(".", "") + @"/" + fileName;
+                    filePath = Path.Join( path, (addSchemaPath ? schema.ToUpper() : string.Empty), _GenPath.Replace(".", ""), fileName);
                 else
-                    filePath = path + (addSchemaPath ? schema.ToUpper() + @"/" : string.Empty) + fileName;
+                    filePath = Path.Join(path, (addSchemaPath ? schema.ToUpper() : string.Empty), fileName);
 
                 Shared.Utils.GeneratorUtils.WriteToFile(filePath, sb.ToString());
             }

--- a/Apstory.ApstoryTsqlCodeGen.DomainGenerator/DomainGen.cs
+++ b/Apstory.ApstoryTsqlCodeGen.DomainGenerator/DomainGen.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -69,7 +70,7 @@ namespace Apstory.ApstoryTsqlCodeGen.DomainGenerator
         {
             try
             {
-                bool addSchema = (schema != "dbo");
+                bool addSchemaPath = (schema != "dbo");
 
                 var sb = new StringBuilder();
                 sb.Append(AddHeader(classNamespace, table.TABLE_NAME, schema));
@@ -86,12 +87,12 @@ namespace Apstory.ApstoryTsqlCodeGen.DomainGenerator
                 LogOutputLine();
                 LogOutput(sb.ToString());
                 LogOutputLine();
-                string fileName = table.TABLE_NAME + "Service" + (addSchema ? "." + schema.ToUpper() : string.Empty) + ".Gen.cs";
+                string fileName = table.TABLE_NAME + "Service" + (addSchemaPath ? "." + schema.ToUpper() : string.Empty) + ".Gen.cs";
                 string filePath;
                 if (_GenPath.Length > 0)
-                    filePath = path + (addSchema ? schema.ToUpper() + @"/" : string.Empty) + _GenPath.Replace(".", "") + @"/" + fileName;
+                    filePath = Path.Join( path, (addSchemaPath ? schema.ToUpper() : string.Empty), _GenPath.Replace(".", ""), fileName);
                 else
-                    filePath = path + (addSchema ? schema.ToUpper() + @"/" : string.Empty) + fileName;
+                    filePath = Path.Join(path, (addSchemaPath ? schema.ToUpper() : string.Empty), fileName);
                 Shared.Utils.GeneratorUtils.WriteToFile(filePath, sb.ToString());
             }
             catch (Exception ex)
@@ -104,7 +105,7 @@ namespace Apstory.ApstoryTsqlCodeGen.DomainGenerator
         {
             try
             {
-                bool addSchema = (schema != "dbo");
+                bool addSchemaPath = (schema != "dbo");
 
                 var sb = new StringBuilder();
                 sb.Append(AddHeaderIndex(classNamespace, tableWithIndex.TABLE_NAME, schema));
@@ -113,12 +114,14 @@ namespace Apstory.ApstoryTsqlCodeGen.DomainGenerator
                 LogOutputLine();
                 LogOutput(sb.ToString());
                 LogOutputLine();
-                string fileName = tableWithIndex.TABLE_NAME + "Service" + (addSchema ? "." + schema.ToUpper() : string.Empty) + ".Index.Gen.cs";
+                string fileName = tableWithIndex.TABLE_NAME + "Service" + (addSchemaPath ? "." + schema.ToUpper() : string.Empty) + ".Index.Gen.cs";
                 string filePath;
+                
                 if (_GenPath.Length > 0)
-                    filePath = path + (addSchema ? schema.ToUpper() + @"/" : string.Empty) + _GenPath.Replace(".", "") + @"/" + fileName;
+                    filePath = Path.Join( path, (addSchemaPath ? schema.ToUpper() : string.Empty), _GenPath.Replace(".", ""), fileName);
                 else
-                    filePath = path + (addSchema ? schema.ToUpper() + @"/" : string.Empty) + fileName;
+                    filePath = Path.Join(path, (addSchemaPath ? schema.ToUpper() : string.Empty), fileName);
+                
                 Shared.Utils.GeneratorUtils.WriteToFile(filePath, sb.ToString());
             }
             catch (Exception ex)

--- a/Apstory.ApstoryTsqlCodeGen.InterfaceGenerator/InterfaceGen.cs
+++ b/Apstory.ApstoryTsqlCodeGen.InterfaceGenerator/InterfaceGen.cs
@@ -2,6 +2,7 @@
 using Apstory.ApstoryTsqlCodeGen.Shared.Service;
 using Apstory.ApstoryTsqlCodeGen.Shared.Models;
 using System;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -68,7 +69,7 @@ namespace Apstory.ApstoryTsqlCodeGen.InterfaceGenerator
         {
             try
             {
-                bool addSchema = (schema != "dbo");
+                bool addSchemaPath = (schema != "dbo");
 
                 var sb = new StringBuilder();
                 sb.Append(AddInterfaceHeader(classNamespace, table.TABLE_NAME, type, schema));
@@ -85,12 +86,13 @@ namespace Apstory.ApstoryTsqlCodeGen.InterfaceGenerator
                 LogOutputLine();
                 LogOutput(sb.ToString());
                 LogOutputLine();
-                string fileName = "I" + table.TABLE_NAME + type + (addSchema ? "." + schema.ToUpper() : "") + ".Gen.cs";
+                string fileName = "I" + table.TABLE_NAME + type + (addSchemaPath ? "." + schema.ToUpper() : "") + ".Gen.cs";
                 string filePath;
+                
                 if (_GenPath.Length > 0)
-                    filePath = path + (addSchema ? schema.ToUpper() + @"/" : string.Empty) + _GenPath.Replace(".", "") + "//" + fileName;
+                    filePath = Path.Join( path, (addSchemaPath ? schema.ToUpper() : string.Empty), _GenPath.Replace(".", ""), fileName);
                 else
-                    filePath = path + (addSchema ? schema.ToUpper() + @"/" : string.Empty) + fileName;
+                    filePath = Path.Join(path, (addSchemaPath ? schema.ToUpper() : string.Empty), fileName);
 
                 Shared.Utils.GeneratorUtils.WriteToFile(filePath, sb.ToString());
             }
@@ -105,7 +107,7 @@ namespace Apstory.ApstoryTsqlCodeGen.InterfaceGenerator
         {
             try
             {
-                bool addSchema = (schema != "dbo");
+                bool addSchemaPath = (schema != "dbo");
 
                 var sb = new StringBuilder();
                 sb.Append(AddInterfaceHeader(classNamespace, tableWithIndex.TABLE_NAME, type, schema));
@@ -114,12 +116,12 @@ namespace Apstory.ApstoryTsqlCodeGen.InterfaceGenerator
                 LogOutputLine();
                 LogOutput(sb.ToString());
                 LogOutputLine();
-                string fileName = "I" + tableWithIndex.TABLE_NAME + type + (addSchema ? "." + schema.ToUpper() : "") + ".Index.Gen.cs";
+                string fileName = "I" + tableWithIndex.TABLE_NAME + type + (addSchemaPath ? "." + schema.ToUpper() : "") + ".Index.Gen.cs";
                 string filePath;
                 if (_GenPath.Length > 0)
-                    filePath = path + (addSchema ? schema.ToUpper() + @"/" : string.Empty) + _GenPath.Replace(".", "") + @"/" + fileName;
+                    filePath = Path.Join( path, (addSchemaPath ? schema.ToUpper() : string.Empty), _GenPath.Replace(".", ""), fileName);
                 else
-                    filePath = path + (addSchema ? schema.ToUpper() + @"/" : string.Empty) + fileName;
+                    filePath = Path.Join(path, (addSchemaPath ? schema.ToUpper() : string.Empty), fileName);
 
                 Shared.Utils.GeneratorUtils.WriteToFile(filePath, sb.ToString());
             }

--- a/Apstory.ApstoryTsqlCodeGen.Main/Program.cs
+++ b/Apstory.ApstoryTsqlCodeGen.Main/Program.cs
@@ -7,6 +7,7 @@ using Apstory.ApstoryTsqlCodeGen.Shared.Utils;
 using Microsoft.Extensions.CommandLineUtils;
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace Apstory.Common.Tsql.Main
@@ -16,6 +17,7 @@ namespace Apstory.Common.Tsql.Main
 
         static void Main(string[] args)
         {
+
             CommandLineApplication commandLineApplication = new CommandLineApplication(throwOnUnexpectedArg: false);
 
             CommandOption classNamespace = commandLineApplication.Option(
@@ -99,35 +101,35 @@ namespace Apstory.Common.Tsql.Main
                 GeneratorUtils.GenPathModelString(genPathList, genPathNamespaceList, "domain", schema),
                 GeneratorUtils.GenPathNamespaceString(genPathNamespaceList, "domain"),
                 true);
-            var domainTask = domainGen.Run($"Domain/{classNamespace}.Domain/", classNamespace, schema, includeForeignKeys);
+            var domainTask = domainGen.Run(Path.Join("Domain", $"{classNamespace}.Domain"), classNamespace, schema, includeForeignKeys);
 
             var modelGen = new ModelGen(tablesRepository,
                 GeneratorUtils.GenPathString(genPathList, "model"),
                 GeneratorUtils.GenPathModelString(genPathList, genPathNamespaceList, "model", schema),
                 GeneratorUtils.GenPathNamespaceString(genPathNamespaceList, "model"),
                 true);
-            var modelTask = modelGen.Run($"Model/{classNamespace}.Model/", classNamespace, schema, convertLongsToString, includeForeignKeys);
+            var modelTask = modelGen.Run(Path.Join("Model", $"{classNamespace}.Model"), classNamespace, schema, convertLongsToString, includeForeignKeys);
 
             var dapperGen = new DapperGen(tablesRepository,
                 GeneratorUtils.GenPathString(genPathList, "dalDapper"),
                 GeneratorUtils.GenPathModelString(genPathList, genPathNamespaceList, "dalDapper", schema),
                 GeneratorUtils.GenPathNamespaceString(genPathNamespaceList, "dalDapper"),
                 true);
-            var dapperTask = dapperGen.Run($"Dal/{classNamespace}.Dal.Dapper/", classNamespace, schema);
+            var dapperTask = dapperGen.Run(Path.Join("Dal", $"{classNamespace}.Dal.Dapper"), classNamespace, schema);
 
             var interfaceDomainGen = new InterfaceGen(tablesRepository,
                 GeneratorUtils.GenPathString(genPathList, "interfaceDomain"),
                 GeneratorUtils.GenPathModelString(genPathList, genPathNamespaceList, "interfaceDomain", schema),
                 GeneratorUtils.GenPathNamespaceString(genPathNamespaceList, "interfaceDomain"),
                 true);
-            var interfaceDomainTask = interfaceDomainGen.Run($"Domain/{classNamespace}.Domain.Interface/", "Service", classNamespace, schema, includeForeignKeys);
+            var interfaceDomainTask = interfaceDomainGen.Run(Path.Join("Domain", $"{classNamespace}.Domain.Interface"), "Service", classNamespace, schema, includeForeignKeys);
 
             var interfaceDalGen = new InterfaceGen(tablesRepository,
                 GeneratorUtils.GenPathString(genPathList, "interfaceDal"),
                 GeneratorUtils.GenPathModelString(genPathList, genPathNamespaceList, "interfaceDal", schema),
                 GeneratorUtils.GenPathNamespaceString(genPathNamespaceList, "interfaceDal"),
                 true);
-            var interfaceDalTask = interfaceDalGen.Run($"Dal/{classNamespace}.Dal.Interface/", "Repository", classNamespace, schema, false);
+            var interfaceDalTask = interfaceDalGen.Run(Path.Join("Dal", $"{classNamespace}.Dal.Interface"), "Repository", classNamespace, schema, false);
             Task.WaitAll(domainTask, dapperTask, interfaceDalTask, interfaceDomainTask, interfaceDalTask, modelTask);
 
             sw.Stop();

--- a/Apstory.ApstoryTsqlCodeGen.ModelGenerator/ModelGen.cs
+++ b/Apstory.ApstoryTsqlCodeGen.ModelGenerator/ModelGen.cs
@@ -2,6 +2,7 @@
 using Apstory.ApstoryTsqlCodeGen.Shared.Service;
 using Apstory.ApstoryTsqlCodeGen.Shared.Models;
 using System;
+using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -70,10 +71,10 @@ namespace Apstory.ApstoryTsqlCodeGen.ModelGenerator
                 string filePath;
 
                 if (_GenPath.Length > 0)
-                    filePath = path + (addSchemaPath ? schema.ToUpper() + @"\" : string.Empty) + _GenPath.Replace(".", "") + "\\" + fileName;
+                    filePath = Path.Join( path, (addSchemaPath ? schema.ToUpper() : string.Empty), _GenPath.Replace(".", ""), fileName);
                 else
-                    filePath = path + (addSchemaPath ? schema.ToUpper() + @"\" : string.Empty) + fileName;
-
+                    filePath = Path.Join(path, (addSchemaPath ? schema.ToUpper() : string.Empty), fileName);
+                
                 Shared.Utils.GeneratorUtils.WriteToFile(filePath, sb.ToString());
             }
             catch (Exception ex)


### PR DESCRIPTION
## Fix

This fix caters for the cross-platform nature of paths. More specifically stemming from a bug where users running Mac code-get would have incorrect files generated for models. 